### PR TITLE
Refactoring + support for testing

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,0 +1,4 @@
+use Mix.Config
+
+config :phoenix, :format_encoders,
+  json: Poison

--- a/examples/dummy_handler.ex
+++ b/examples/dummy_handler.ex
@@ -1,102 +1,93 @@
 defmodule RestAuth.DummyHandler do
-  @behaviour RestAuth.HandlerBehaviour
-
-  @fake_user %{
-                name: "Fake User",
-                password: "acceptme", #cleartext, do NOT do this, use Comeonin or similar!
-                company_id: 33
-              }
-
-  require Logger
-  alias RestAuth.CacheService
-
   @moduledoc """
   Sample Handler module showing intended flow and a sample set of
-  internal helpers. Will throw warnings if used in an actual app.
+  internal helpers.
+
   Intention is to be inspiration for your own handler module.
   """
 
+  @behaviour RestAuth.HandlerBehaviour
+
+  @fake_user %{
+    name: "Fake User",
+    password: "acceptme", # cleartext, do NOT do this, use Comeonin or similar!
+    company_id: 33
+  }
+
+  require Logger
+  alias RestAuth.CacheService
 
   ################################
   # BEHAVIOUR REQUIRED FUNCTIONS #
   ################################
   def load_user_data(username, raw_password) do
+    # This is normally a DB lookup based on the username
+    user =
+      if username == "fakeuser@example.com" do
+        @fake_user
+      else
+        nil
+      end
 
-    #This is normally a DB lookup based on the username
-    if username == "fakeuser@example.com" do
-      @fake_user
-    else
-      nil
-    end
-    |> case do
+    case user do
       nil ->
+        dummy_check_password()
         {:error, "User not found or wrong password"}
       user ->
-        case check_password(user.password, raw_password) do
-          true ->
-            Logger.debug "Password accepted, loading user data"
-            load_user_data(user)
-          false ->
-            Logger.debug "#{user.username}[#{user.name}] did not match password"
-            {:error, "User not found or wrong password"}
+        if check_password(user.password, raw_password) do
+          Logger.debug "Password accepted, loading user data"
+          load_user_data(user)
+        else
+          Logger.debug "#{user.username}[#{user.name}] did not match password"
+          {:error, "User not found or wrong password"}
         end
     end
   end
 
   def load_user_data(user) do
     metadata = %{
-      "name" => user.name,
-      "company_id" => user.company_id,
+      name: user.name,
+      company_id: user.company_id,
     }
 
     # We put a versioning in the token signature
-    # to be able to do changes to our token strategy later.
+    # to be able to easily do changes to our token strategy later.
     token_data = %{user_id: user.id, version: 1}
-                 |> Poison.encode!
     token = Phoenix.Token.sign(RestAuth.FakeEndpoint, get_salt(), token_data)
 
-    authority = %RestAuth.Authority{
-                  token: token,
-                  roles: get_roles(user),
-                  user_id: user.id,
-                  metadata: metadata,
-                  anonymous: false
-                }
+    authority =
+      %RestAuth.Authority{
+        token: token,
+        roles: get_roles(user),
+        user_id: user.id,
+        metadata: metadata,
+        anonymous: false
+      }
     write_token_to_db(authority)
     CacheService.put_user(authority)
     {:ok, authority}
   end
 
-  @doc """
-  Decodes a token
-  """
   def load_user_data_from_token(token) do
     case Phoenix.Token.verify(RestAuth.FakeEndpoint, get_salt(), token) do
-      {:ok, token_data_raw} ->
-        Logger.debug "token_data_raw is #{inspect token_data_raw}"
-        case Poison.decode(token_data_raw) do
-          {:ok, %{"user_id" => user_id, "version" => _}} ->
-            authority = %RestAuth.Authority{
-                          user_id: user_id,
-                          token: token
-                        }
-            case CacheService.get_user(authority) do
-              :not_found ->
-                load_token_from_db(authority)
-                |> case do
-                  nil ->
-                    {:error, :invalid}
-                  authority ->
-                    CacheService.put_user(authority)
-                    {:ok, authority}
-                end
-              {:ok, authority} ->
+      {:ok, %{user_id: user_id, version: 1}} ->
+        authority = %RestAuth.Authority{user_id: user_id, token: token}
+
+        case CacheService.get_user(authority) do
+          :not_found ->
+            case load_token_from_db(authority) do
+              nil ->
+                {:error, "token invalid"}
+              authority ->
+                CacheService.put_user(authority)
                 {:ok, authority}
             end
-          {:ok, _} ->
-            {:error, "token expired"}
+          {:ok, authority} ->
+            {:ok, authority}
         end
-      #Both error conditions will halt the plug pipeline
+      {:ok, _} ->
+        {:error, "token expired"}
+      # Error conditions will halt the plug pipeline
       {:error, :expired} ->
         {:error, "token expired"}
       {:error, :invalid} ->
@@ -104,35 +95,20 @@ defmodule RestAuth.DummyHandler do
     end
   end
 
-
-
-  #Defined with some default values to appease the behaviour gods
-  def can_access_item?(%RestAuth.Authority{user_id: _user_id}, _category, _target_id), do: true
-  def invalidate_user_acl(%RestAuth.Authority{user_id: _user_id}), do: :ok
-
   def invalidate_token(authority = %RestAuth.Authority{}) do
     delete_token_from_db(authority)
-    CacheService.invalidate_token(authority)
-    |> case do
+    case CacheService.invalidate_token(authority) do
       {:error, nodes} ->
         Logger.error "Not able to delete tokens on nodes: #{inspect nodes}"
         {:error, "Failed to delete on #{length(nodes)} node(s)"}
-      _ ->
+      {:ok, _} ->
         :ok
     end
   end
 
-  def invalidate_user(authority = %RestAuth.Authority{}) do
-    delete_all_tokens_from_db(authority)
-    CacheService.invalidate_user(authority)
-    |> case do
-      {:error, nodes} ->
-        Logger.error "Not able to delete tokens on nodes: #{inspect nodes}"
-        {:error, "Failed to delete on #{length(nodes)} node(s)"}
-      _ ->
-        :ok
-    end
-  end
+  ####################################
+  # OPTIONAL CONFIGURATION CALLBACKS #
+  ####################################
 
   def write_cookie?(), do: false
 
@@ -140,18 +116,45 @@ defmodule RestAuth.DummyHandler do
 
   def anonymous_roles(), do: []
 
+  ######################
+  # OPTIONAL CALLBACKS #
+  ######################
+
+  # These are not used by the library directly, but are a suggestion on
+  # possible further usage in your application
+
+  def can_access_item?(%RestAuth.Authority{user_id: _user_id}, _category, _target_id), do: true
+
+  def invalidate_user_acl(%RestAuth.Authority{user_id: _user_id}), do: :ok
+
+  def invalidate_user(authority = %RestAuth.Authority{}) do
+    delete_all_tokens_from_db(authority)
+    case CacheService.invalidate_user(authority) do
+      {:error, nodes} ->
+        Logger.error "Not able to delete tokens on nodes: #{inspect nodes}"
+        {:error, "Failed to delete on #{length(nodes)} node(s)"}
+      {:ok, _} ->
+        :ok
+    end
+  end
+
   ###########
   # HELPERS #
   ###########
 
   defp get_salt() do
-    "set_your_own_loooong_salt_here"
+    "set_your_own_loooong_salt_here_or_lookup_in_endpoint_config"
   end
 
-
   defp check_password(encoded_password, raw_password) do
-    #This should normally lean on Comeonin or similar libraries
+    # This should normally lean on Comeonin or similar libraries
     encoded_password == raw_password
+  end
+
+  defp dummy_check_password() do
+    # This should simulate a similar computational cost to check_password
+    # to prevent timing attacks
+    true
   end
 
   defp get_roles(_user) do
@@ -159,27 +162,27 @@ defmodule RestAuth.DummyHandler do
     ["user", "admin"]
   end
 
-  #Writes to cache and to db
-  defp write_token_to_db(authority) do
+  defp write_token_to_db(_authority) do
     # Write the authority to database here.
     # Either attempt to load based on .user_id and .token before
     # writing or put in a unique constraint to make sure you
     # dont end up with multiple identical tokens.
-    authority
+    :ok
   end
 
   defp load_token_from_db(authority) do
     # Just setting some metadata as a sample here.
     # This function should normally reconstruct the entire
     # Authority from the database.
-    %{authority | metadata: %{"name" => @fake_user.name}}
+    %{authority | metadata: %{name: @fake_user.name}}
   end
 
-  defp delete_token_from_db(%RestAuth.Authority{user_id: _user_id, token: _token}) do
-    #Function included as sample
+  defp delete_token_from_db(_authority) do
+    # Counterpart to write_token_to_db/1
+    :ok
   end
 
-  defp delete_all_tokens_from_db(%RestAuth.Authority{user_id: _user_id}) do
-    #Function included as sample
+  defp delete_all_tokens_from_db(_authority) do
+    :ok
   end
 end

--- a/examples/dummy_handler.ex
+++ b/examples/dummy_handler.ex
@@ -11,7 +11,7 @@ defmodule RestAuth.DummyHandler do
   alias RestAuth.CacheService
 
   @moduledoc """
-  Sample Handler module showing intended flow and a sample set of 
+  Sample Handler module showing intended flow and a sample set of
   internal helpers. Will throw warnings if used in an actual app.
   Intention is to be inspiration for your own handler module.
   """
@@ -45,13 +45,13 @@ defmodule RestAuth.DummyHandler do
 
   def load_user_data(user) do
     metadata = %{
-      "name" => user.name, 
-      "company_id" => user.company_id, 
+      "name" => user.name,
+      "company_id" => user.company_id,
     }
 
     # We put a versioning in the token signature
     # to be able to do changes to our token strategy later.
-    token_data = %{user_id: user.id, version: 1} 
+    token_data = %{user_id: user.id, version: 1}
                  |> Poison.encode!
     token = Phoenix.Token.sign(RestAuth.FakeEndpoint, get_salt(), token_data)
 
@@ -104,7 +104,7 @@ defmodule RestAuth.DummyHandler do
     end
   end
 
-  
+
 
   #Defined with some default values to appease the behaviour gods
   def can_access_item?(%RestAuth.Authority{user_id: _user_id}, _category, _target_id), do: true
@@ -134,7 +134,11 @@ defmodule RestAuth.DummyHandler do
     end
   end
 
+  def write_cookie?(), do: false
 
+  def default_required_roles(), do: []
+
+  def anonymous_roles(), do: []
 
   ###########
   # HELPERS #
@@ -144,7 +148,7 @@ defmodule RestAuth.DummyHandler do
     "set_your_own_loooong_salt_here"
   end
 
-  
+
   defp check_password(encoded_password, raw_password) do
     #This should normally lean on Comeonin or similar libraries
     encoded_password == raw_password
@@ -163,7 +167,7 @@ defmodule RestAuth.DummyHandler do
     # dont end up with multiple identical tokens.
     authority
   end
-  
+
   defp load_token_from_db(authority) do
     # Just setting some metadata as a sample here.
     # This function should normally reconstruct the entire
@@ -178,5 +182,4 @@ defmodule RestAuth.DummyHandler do
   defp delete_all_tokens_from_db(%RestAuth.Authority{user_id: _user_id}) do
     #Function included as sample
   end
-
 end

--- a/lib/rest_auth.ex
+++ b/lib/rest_auth.ex
@@ -1,67 +1,44 @@
 defmodule RestAuth do
-  use Application
-  require Logger
-
   @moduledoc """
   `RestAuth` is a declarative ACL library for Phoenix. It functions by declaring a
   controller level plug with a set of roles specified for the given action. It also
   provides a framework for doing per-item-ACL with ETS backed caching built in.
 
-  To set up and use `RestAuth` you need to specify some configuration for sane defaults
-  and specify a handler module based on the `RestAuth.HandlerBehaviour` behaviour.
-  
-  You also need to set up an authentication controller of sorts that calls  
+  To set up and use `RestAuth` you need to specify some configuration for sane
+  defaults. All the configuration is provided using a plug:
+
+     plug RestAuth.Configure, handler: MyHandler
+
+  The only option accepted right now is the `:handler` module that implements
+  the `RestAuth.Handler` behaviour. An example handler is provided in the
+  `examples/dummy_handler.ex` file.
+
+  You also need to set up an authentication controller of sorts that calls
   `RestAuth.Controller.login/3` and `RestAuth.Controller.logout/3` functions
 
   A typical sample usage in a controller looks like so (pulled from `Restauth.Restrict` documentation):
 
-  ```
-    @rest_auth_roles  [
-                        {:index, ["user"]},
-                        {:create, ["admin"]},
-                        {:update, ["admin"]},
-                        {:show, ["admin"]},
-                        {:delete, ["admin"]}
-                       ]
-    plug RestAuth.Restrict, @rest_auth_roles
-  ```
+      @rest_auth_roles  [
+        {:index, ["user"]},
+        {:create, ["admin"]},
+        {:update, ["admin"]},
+        {:show, ["admin"]},
+        {:delete, ["admin"]}
+      ]
+      plug RestAuth.Restrict, @rest_auth_roles
 
   The handler module provided by the user takes full responsibility for loading
-  user data from the database and caching the data using `RestAuth.CacheService` etc.
-  This library aims to be a slightly oppinionated framework for you to build your own
-  logic on top of. After having implemented the behaviour `RestAuth` should rarely get
-  in the way of anyhting.
+  user data from the database and caching the data using `RestAuth.CacheService`
+  if caching is required.
 
-  
-  Default configuration values looks like:
-
-  ```
-  config :rest_auth,
-    handler: RestAuth.DummyhHandler,
-    token_service_name: RestAuth.CacheService,
-    anonymous_roles: [],
-    default_required_roles: [],
-    write_cookie: false
-  ```
-  
-  You need to at least set handler and the default roles.
-  ```
-  config :rest_auth,
-    handler: YourApp.RestAuthHandler,
-    token_service_name: YourOwnTokenServiceName, 
-    anonymous_roles: ["anonymous"],
-    default_required_roles: ["user"],
-    write_cookie: true
-  ```
-  
+  This library aims to be a slightly oppinionated framework for you to build your
+  own logic on top of. After having implemented the behaviour `RestAuth` should
+  rarely get in the way of anyhting.
   """
-  
+  use Application
+
   @doc false
   def start(_type, _args) do
-    if Application.get_env(:rest_auth, :handler, RestAuth.DummyHandler) == RestAuth.DummyHandler do
-      Logger.error "DUMMY RESTAUTH HANDLER IS SET, CREATE YOUR OWN BEFORE USING LIBRARY"
-    end
     RestAuth.Supervisor.start_link
   end
-
 end

--- a/lib/rest_auth/authority.ex
+++ b/lib/rest_auth/authority.ex
@@ -1,12 +1,12 @@
 defmodule RestAuth.Authority do
-
   @moduledoc """
   An authority struct.
+
   Used to hold information about the current user/authority granted.
   """
 
   @typedoc """
-  Roles defaults to either [] or the specified anonymous roles in your config.
+  Roles defaults to an empty list.
   Anonymous defaults to `true`. Remember to set `anonymous: false` on successful creation
   of `RestAuth.Authority` in your handler!
 
@@ -21,9 +21,9 @@ defmodule RestAuth.Authority do
 
   @derive {Poison.Encoder, only: [:token, :user_id, :roles, :metadata]}
   defstruct [
-    :token, 
-    :user_id, 
-    {:roles, Application.get_env(:rest_auth, :anonymous_roles, [])},
+    :token,
+    :user_id,
+    {:roles, []},
     {:metadata, %{}},
     {:anonymous, true}
   ]

--- a/lib/rest_auth/cache_service.ex
+++ b/lib/rest_auth/cache_service.ex
@@ -1,140 +1,130 @@
 defmodule RestAuth.CacheService do
+  @moduledoc """
+  Generic caching service to be used by the user implemented handler module.
+
+  Most functions from the handler, should use the cache service for best
+  performance and behaviour.
+
+  The data is cached in ETS tables. The service expects a homogeneous
+  node setup where each node has a process called `#{__MODULE__}` that can be
+  used for communication. All writes are dispatched through all the nodes using
+  `GenServer.multi_call/4`, while reads are dirty from the local ETS table.
+  Using this cache without nodes being connected will leave you unable to
+  invalidate acl or kill off user sessions.
+  """
   use GenServer
 
-  @genserver_name Application.get_env(:rest_auth, :cache_service_name, RestAuth.CacheService)
-  @ets_token_table :rest_auth_token_cache
-  @ets_acl_table :rest_auth_acl_cache
+  @genserver_name Application.get_env(:rest_auth, :cache_service_name, __MODULE__)
+  @ets_token_table Module.concat(@genserver_name, Tokens)
+  @ets_acl_table Module.concat(@genserver_name, Acl)
 
-  @moduledoc """
-  Generic caching service to be used by the user implemented handler module. 
-  Has API style meant to be used by the handler and most access should be routed through there. 
-  
-  The module uses `GenServer.multi_call/4` to flush caches and invalidations out to all
-  the nodes. Using this cache without nodes being connected will leave you unable to 
-  invalidate acl or kill off user sessions.
-
-  The cache is backed by ets tables and supports read concurrency.
-  """
+  @type category :: String.t
+  @type target_id :: any
 
   @doc """
   Looks up a user in the cache based on the authority.
-  `user_id` and `token` fields needs to be set for this 
-  function to look up anything sensible.
+
+  Requires `:user_id` and `:token` fields to be set in the authority struct.
   """
-  @spec put_user(authority::RestAuth.Authority.t) :: :not_found | {:ok, RestAuth.Authority.t}
-  def get_user(%RestAuth.Authority{user_id: user_id, token: token}) when not is_nil(user_id) and not is_nil(token) do
-    ## check cache
-    case :ets.match_object(@ets_token_table, {user_id, token, :_}) do
+  @spec put_user(RestAuth.Authority.t) :: :not_found | {:ok, RestAuth.Authority.t}
+  def get_user(%RestAuth.Authority{user_id: user_id, token: token})
+      when not is_nil(user_id) and not is_nil(token) do
+    case :ets.match(@ets_token_table, {user_id, token, :"$1"}) do
       [] ->
         :not_found
-      [{_, _, data}] ->
+      [data] ->
         {:ok, data}
     end
-
   end
 
   @doc """
-  Synchronously puts a user in the cache.
-  
-  The call is syncronous to try to prevent multiple lookups / cache puts across the nodes.
-  Returns
-    * `{:ok, Integer.t}` If all nodes stored the authority just fine with the int being how many nodes it stored on.
-    * `{:error, [Node.t]}` with a list of the bad nodes. Mainly to be used for logging purposes. 
+  Looks up in the cache if a user can access an item in the system.
+
+  Returns a boolean or `:not_found` if no information is found in the cache.
   """
-  @spec put_user(authority::RestAuth.Authority.t) :: :ok | {:error, [Node.t]}
-  def put_user(auth = %RestAuth.Authority{user_id: user_id, token: token}) when not is_nil(user_id) and not is_nil(token) do
-    GenServer.multi_call([node() | Node.list()], @genserver_name, {:put_token, user_id, token, auth}, 5000)
-    |> case do
-      {nodes, []} ->
-        {:ok, length(nodes)}
-      {_, nodes} ->
-        {:error, nodes}
-    end
-  end
-
-  @doc """
-  Invalidates an authority based on the set `user_id` and `token`.
-  Returns
-    * `{:ok, Integer.t}` If all nodes invalidated the authority just fine with the int being how many nodes it invalidated on.
-    * `{:error, [Node.t]}` with a list of the bad nodes. Mainly to be used for logging purposes. 
-  """
-  @spec invalidate_token(authority::RestAuth.Authority.t) :: :ok | {:error, [Node.t]}
-  def invalidate_token(%RestAuth.Authority{user_id: user_id, token: token}) when not is_nil(user_id) and not is_nil(token) do
-    GenServer.multi_call([node() | Node.list()], @genserver_name, {:delete_token, user_id, token}, 5_000)
-    |> case do
-      {nodes, []} ->
-        {:ok, length(nodes)}
-      {_, nodes} ->
-        {:error, nodes}
-    end
-  end
-
-  @doc """
-  Invalidates all authorities for a given `user_id`.
-  
-  Returns
-    * `{:ok, Integer.t}` If all nodes invalidated the authority just fine with the int being how many nodes it invalidated on.
-    * `{:error, [Node.t]}` with a list of the bad nodes. Mainly to be used for logging purposes. 
-  """
-  @spec invalidate_user(authority::RestAuth.Authority.t) :: :ok | {:error, [Node.t]}
-  def invalidate_user(%RestAuth.Authority{user_id: user_id}) when not is_nil(user_id) do
-    GenServer.multi_call([node() | Node.list()], @genserver_name, {:delete_all_token, user_id}, 5_000)
-    |> case do
-      {nodes, []} ->
-        {:ok, length(nodes)}
-      {_, nodes} ->
-        {:error, nodes}
-    end
-  end
-
-  @doc """
-  Looks up if a user can access an item in the system. 
-  Returns `:not_found` if there is nothing in the cache and a boolean result if there is.
-  """ 
-  @spec can_user_access?(authority::RestAuth.Authority.t, category :: String.t, target_id :: any()) :: :not_found | (true | false) 
-  def can_user_access?(%RestAuth.Authority{user_id: user_id}, category, target_id)do
-    ## check cache
-    case :ets.match_object(@ets_acl_table, {user_id, category, target_id, :_ }) do
+  @spec can_user_access?(RestAuth.Authority.t, category, target_id) :: :not_found | boolean
+  def can_user_access?(%RestAuth.Authority{user_id: user_id}, category, target_id) do
+    case :ets.match(@ets_acl_table, {user_id, category, target_id, :"$1"}) do
       [] ->
         :not_found
-      [{_user_id, _category, _target_id, data}] ->
+      [data] ->
         data
     end
   end
 
+
   @doc """
-  Sets user access for a user_id / category / item id in the caching layer.
-  
-  Returns
-    * `{:ok, Integer.t}` If all nodes stored the access control with int being how many nodes it invalidated on.
-    * `{:error, [Node.t]}` with a list of the bad nodes. Mainly to be used for logging purposes. 
+  Synchronously puts a user in the cache.
+
+  The call is synchronous to limit concurrent updates from multiple nodes.
+
+  On success returns the count of nodes written to, on failure the list of nodes
+  with failed writes.
   """
-  @spec set_user_access(authority::RestAuth.Authority.t, category :: String.t, target_id :: any(), allowed :: boolean) :: :ok | {:error, [Node.t]}
-  def set_user_access(%RestAuth.Authority{user_id: user_id}, category, target_id, allowed) do
-    GenServer.multi_call([node() | Node.list()], @genserver_name, {:put_acl, user_id, category, target_id, allowed}, 5_000)
-    |> case do
-      {nodes, []} ->
-        {:ok, length(nodes)}
-      {_, nodes} ->
-        {:error, nodes}
-    end
+  @spec put_user(RestAuth.Authority.t) ::
+        {:ok, non_neg_integer} | {:error, [Node.t]}
+  def put_user(auth = %RestAuth.Authority{user_id: user_id, token: token})
+      when not is_nil(user_id) and not is_nil(token) do
+    multi_call({:put_token, user_id, token, auth})
+  end
+
+  @doc """
+  Invalidates an authority based on the set `user_id` and `token`.
+
+  On success returns the count of nodes written to, on failure the list of nodes
+  with failed writes.
+  """
+  @spec invalidate_token(RestAuth.Authority.t) ::
+        {:ok, non_neg_integer} | {:error, [Node.t]}
+  def invalidate_token(%RestAuth.Authority{user_id: user_id, token: token})
+      when not is_nil(user_id) and not is_nil(token) do
+    multi_call({:delete_token, user_id, token})
+  end
+
+  @doc """
+  Invalidates all authorities for a given `user_id`.
+
+  On success returns the count of nodes written to, on failure the list of nodes
+  with failed writes.
+  """
+  @spec invalidate_user(RestAuth.Authority.t) ::
+        {:ok, non_neg_integer} | {:error, [Node.t]}
+  def invalidate_user(%RestAuth.Authority{user_id: user_id})
+      when not is_nil(user_id) do
+    multi_call({:delete_all_token, user_id})
+  end
+
+  @doc """
+  Sets user access for a `user_id`, `category` and `target_id` in the caching layer.
+
+  On success returns the count of nodes written to, on failure the list of nodes
+  with failed writes.
+  """
+  @spec set_user_access(RestAuth.Authority.t, category, target_id, boolean) ::
+        {:ok, non_neg_integer} | {:error, [Node.t]}
+  def set_user_access(%RestAuth.Authority{user_id: user_id}, category, target_id, allowed?)
+      when not is_nil(user_id) and is_boolean(allowed?) do
+    multi_call({:put_acl, user_id, category, target_id, allowed?})
   end
 
   @doc """
   Invalidates all acls for a given `user_id` in a `RestAuth.Authority`.
-  
-  Returns
-    * `{:ok, Integer.t}` If all nodes invalidated the item acl just fine with the int being how many nodes it invalidated on.
-    * `{:error, [Node.t]}` with a list of the bad nodes. Mainly to be used for logging purposes. 
+
+  On success returns the count of nodes written to, on failure the list of nodes
+  with failed writes.
   """
-  @spec invalidate_user_acl(authority::RestAuth.Authority.t) :: :ok | {:error, [Node.t]}
-  def invalidate_user_acl(%RestAuth.Authority{user_id: user_id}) when not is_nil(user_id) do
-    GenServer.multi_call([node() | Node.list()], @genserver_name, {:delete_acl, user_id}, 5_000)
-    |> case do
-      {nodes, []} ->
-        {:ok, length(nodes)}
-      {_, nodes} ->
-        {:error, nodes}
+  @spec invalidate_user_acl(RestAuth.Authority.t) ::
+        {:ok, non_neg_integer} | {:error, [Node.t]}
+  def invalidate_user_acl(%RestAuth.Authority{user_id: user_id})
+      when not is_nil(user_id) do
+    multi_call({:delete_acl, user_id})
+  end
+
+  defp multi_call(msg) do
+    nodes = [node() | Node.list()]
+    case GenServer.multi_call(nodes, @genserver_name, msg, 5_000) do
+      {nodes, []} -> {:ok, length(nodes)}
+      {_, failed} -> {:error, failed}
     end
   end
 
@@ -142,6 +132,7 @@ defmodule RestAuth.CacheService do
   # GENSERVER CODE #
   ##################
 
+  @doc false
   def init(_args) do
     :ets.new(@ets_token_table, [:named_table, :bag, :protected, read_concurrency: true])
     :ets.new(@ets_acl_table, [:named_table, :bag, :protected, read_concurrency: true])
@@ -149,8 +140,8 @@ defmodule RestAuth.CacheService do
   end
 
   @doc false
-  def start_link() do
-    GenServer.start_link(__MODULE__, %{}, [name: @genserver_name])
+  def start_link(opts \\ []) do
+    GenServer.start_link(__MODULE__, %{}, [name: @genserver_name] ++ opts)
   end
 
   def handle_call({:put_token, user_id, token, data}, _from, state) do
@@ -177,7 +168,4 @@ defmodule RestAuth.CacheService do
     :ets.match_delete(@ets_acl_table, {user_id, :_, :_, :_})
     {:reply, :ok, state}
   end
-
-
-
 end

--- a/lib/rest_auth/controller.ex
+++ b/lib/rest_auth/controller.ex
@@ -73,7 +73,7 @@ defmodule RestAuth.Controller do
   def logout(conn) do
     handler = conn.private.rest_auth_handler
     auth = RestAuth.Utility.get_authority(conn)
-    handler.invalidate_token(auth)
+    :ok = handler.invalidate_token(auth)
     conn
     |> write_cookie("deleted", handler)
     |> put_status(200)

--- a/lib/rest_auth/controller.ex
+++ b/lib/rest_auth/controller.ex
@@ -82,7 +82,7 @@ defmodule RestAuth.Controller do
   end
 
   defp write_cookie(conn, value, handler) do
-    if handler.write_cookie?() do
+    if function_exported(handler, :write_cookie?, 0) and handler.write_cookie?() do
       put_resp_cookie(conn, "x-auth-token", value)
     else
       conn

--- a/lib/rest_auth/controller.ex
+++ b/lib/rest_auth/controller.ex
@@ -1,82 +1,73 @@
 defmodule RestAuth.Controller do
-  require Logger
-  import Phoenix.Controller, only: [json: 2]
-  import Plug.Conn, only: [put_status: 2, halt: 1, put_resp_cookie: 3] 
-
-  @write_cookie Application.get_env(:rest_auth, :write_cookie, false)
-
   @moduledoc """
   Generic controller handling login and logout.
   """
 
+  require Logger
+  import Phoenix.Controller, only: [json: 2]
+  import Plug.Conn, only: [put_status: 2, halt: 1, put_resp_cookie: 3] 
+
   @doc """
   Call this function from your authentication controller.
-  It will write the token to a cookie if `:write_cookie` is set to 
-  `true` in the `:rest_auth` configuration. Defaults to false
 
-  ```
-  def login(conn, params) do
-    RestAuth.Controller.login(conn, params, write_cookie: true)
-  end
-  ```
-  """
-  def login(conn, params) do
-    username = Map.get(params, "username", :error)
-    raw_password = Map.get(params, "password", :error)
+  It will write the token to a cookie if handler is configured to write cookies.
 
-    if raw_password == :error or username == :error do
-      conn
-      |> put_status(403)
-      |> json(%{"error" => "Username and/or password missing"})
-      |> halt
-    else
-      case handler().load_user_data(username, raw_password) do
-        { :ok, authority = %RestAuth.Authority{} } ->
-          conn = if @write_cookie do
-            put_resp_cookie(conn, "x-auth-token", authority.token)#, secure: true)
-          else
-            conn
-          end
-          conn
-          |> json(%{"data" => authority})
-        { :error, reason } ->
-          conn
-          |> put_status(403)
-          |> json(%{"error" => reason})
-          |> halt
+  # Example
+
+      def login(conn, params) do
+        RestAuth.Controller.login(conn, params, write_cookie: true)
       end
+
+  """
+  def login(conn, %{"username" => username, "password" => raw_password}) do
+    handler = conn.private.rest_auth_handler
+    case handler.load_user_data(username, raw_password) do
+      {:ok, authority = %RestAuth.Authority{}} ->
+        conn
+        |> write_cookie(authority.token, handler)
+        |> json(%{"data" => authority})
+      {:error, reason} ->
+        conn
+        |> put_status(403)
+        |> json(%{"error" => reason})
+        |> halt
     end
   end
+  def login(conn, _params) do
+    conn
+    |> put_status(403)
+    |> json(%{"error" => "Username and/or password missing"})
+    |> halt
+  end
 
   @doc """
   Call this function from your authentication controller.
-  It will write the token to a cookie if `:write_cookie` is set to 
-  `true` in the `:rest_auth` configuration. Defaults to false
 
-  ```
-  def logout(conn, params) do
-    RestAuth.Controller.logout(conn)
-  end
-  ```
-  
+  It will write the token to a cookie if handler is set to write cookies.
+
+  # Example
+
+      def logout(conn, params) do
+        RestAuth.Controller.logout(conn)
+      end
+
   """
   def logout(conn) do
+    handler = conn.private.rest_auth_handler
     auth = RestAuth.Utility.get_authority(conn)
-    handler().invalidate_token(auth)
-    conn = 
-      if @write_cookie do
-        put_resp_cookie(conn, "x-auth-token", "deleted")
-      else
-        conn
-      end
+    handler.invalidate_token(auth)
     conn
+    |> write_cookie("deleted", handler)
     |> put_status(200)
     |> json(%{"success" => "logged out"})
     |> halt
   end
 
-  defp handler() do
-    Application.get_env(:rest_auth, :handler, RestAuth.DummyHandler)
+  defp write_cookie(conn, value, handler) do
+    if handler.write_cookie?() do
+      put_resp_cookie(conn, "x-auth-token", value)
+    else
+      conn
+    end
   end
-
 end

--- a/lib/rest_auth/controller.ex
+++ b/lib/rest_auth/controller.ex
@@ -12,10 +12,28 @@ defmodule RestAuth.Controller do
 
   It will write the token to a cookie if handler is configured to write cookies.
 
+  The function will respond either successfully with data from the authority
+  struct returned by the `RestAuth.Handler.load_user_data/2` callback:
+
+      {
+        "data": {
+          "token": "g3QAAAACZAAEZGF0YW....udlCH1tpI8oPfIE+BsMcrXj2A=",
+          "user_id": 1,
+          "roles": ["user", "admin"],
+          "metadata":  {"name": "John Doe"}
+        }
+      }
+
+  Or with the returned error:
+
+      {
+        "error": <your string here>
+      }
+
   # Example
 
       def login(conn, params) do
-        RestAuth.Controller.login(conn, params, write_cookie: true)
+        RestAuth.Controller.login(conn, params)
       end
 
   """

--- a/lib/rest_auth/controller.ex
+++ b/lib/rest_auth/controller.ex
@@ -82,7 +82,7 @@ defmodule RestAuth.Controller do
   end
 
   defp write_cookie(conn, value, handler) do
-    if function_exported(handler, :write_cookie?, 0) and handler.write_cookie?() do
+    if function_exported?(handler, :write_cookie?, 0) and handler.write_cookie?() do
       put_resp_cookie(conn, "x-auth-token", value)
     else
       conn

--- a/lib/rest_auth/handler.ex
+++ b/lib/rest_auth/handler.ex
@@ -57,6 +57,8 @@ defmodule RestAuth.Handler do
   @doc """
   Verifies the given authority can access an item in the system.
 
+  The callback is not used by the library and is an advice of use of the library.
+
   Typically does a lookup for permissions in the caching layer first,
   then in the database if it is not found there.
 
@@ -67,10 +69,13 @@ defmodule RestAuth.Handler do
   granting or denying access to things.
   """
   @callback can_access_item?(RestAuth.Authority.t, category :: String.t, target_id :: any()) :: boolean()
+  @optional_callbacks [can_access_item?: 3]
 
   @doc """
   Invalidates all user acl based off the `user_id` in the `RestAuth.Authority`
   struct.
+
+  The callback is not used by the library and is an advice of use of the library.
 
   Typically used to clear the acl for a user after being granted access to
   something with intention of refreshing the acl data on subsequent requests.
@@ -79,6 +84,7 @@ defmodule RestAuth.Handler do
   """
   @callback invalidate_user_acl(authority :: RestAuth.Authority.t) ::
             :ok | {:error, reason :: String.t}
+  @optional_callbacks [invalidate_user_acl: 1]
 
   @doc """
   Invalidates a token.
@@ -92,6 +98,8 @@ defmodule RestAuth.Handler do
   @doc """
   Invalidates a user.
 
+  The callback is not used by the library and is an advice of use of the library.
+
   This effectively logs out all active sessions across the application
 
   Typically this invalidates all the tokens in the cacheservice and deletes any
@@ -99,6 +107,7 @@ defmodule RestAuth.Handler do
   """
   @callback invalidate_user(authority :: RestAuth.Authority.t) ::
             :ok | {:error, reason :: String.t}
+  @optional_callbacks [invalidate_user: 1]
 
   @doc """
   A configuration callback to determine, if mechanisms of `RestAuth` should

--- a/lib/rest_auth/handler.ex
+++ b/lib/rest_auth/handler.ex
@@ -1,6 +1,7 @@
-defmodule RestAuth.HandlerBehaviour do
-@moduledoc """
-  This behavior is a requirement to use RestAUth.
+defmodule RestAuth.Handler do
+  @moduledoc """
+  This behavior is a requirement to use RestAuth.
+
   Please refer to the docs for each function to see how to implement the callbacks.
   """
 
@@ -96,6 +97,25 @@ defmodule RestAuth.HandlerBehaviour do
   """
   @callback invalidate_user(authority :: RestAuth.Authority.t) :: :ok | {:error, reason :: String.t}
 
+  @doc """
+  A configuration callback to determine, if mechanisms of `RestAuth` should
+  be writing into cookies.
 
-  
-end  
+  Default implementation would return `false`.
+  """
+  @callback write_cookie?() :: boolean
+
+  @doc """
+  A configuration callback to provide default required roles.
+
+  Simplest implementation is to return `[]`.
+  """
+  @callback default_required_roles() :: [String.t]
+
+  @doc """
+  A configuration collback to provide anonymous roles.
+
+  Simplest implementation is to return `[]`.
+  """
+  @callback anonymous_roles() :: [String.t]
+end

--- a/lib/rest_auth/handler.ex
+++ b/lib/rest_auth/handler.ex
@@ -101,21 +101,24 @@ defmodule RestAuth.Handler do
   A configuration callback to determine, if mechanisms of `RestAuth` should
   be writing into cookies.
 
-  Default implementation would return `false`.
+  If not implemented, `false` is used.
   """
   @callback write_cookie?() :: boolean
+  @optional_callbacks [write_cookie?: 0]
 
   @doc """
   A configuration callback to provide default required roles.
 
-  Simplest implementation is to return `[]`.
+  If not implemented, `[]` is used.
   """
   @callback default_required_roles() :: [String.t]
+  @optional_callbacks [default_required_roles: 0]
 
   @doc """
   A configuration collback to provide anonymous roles.
 
-  Simplest implementation is to return `[]`.
+  If not implemented, `[]` is used.
   """
   @callback anonymous_roles() :: [String.t]
+  @optional_callbacks [anonymous_roles: 0]
 end

--- a/lib/rest_auth/handler.ex
+++ b/lib/rest_auth/handler.ex
@@ -1,84 +1,80 @@
 defmodule RestAuth.Handler do
   @moduledoc """
-  This behavior is a requirement to use RestAuth.
-
-  Please refer to the docs for each function to see how to implement the callbacks.
+  The primary behaviour that drives the use of `RestAuth` in a project.
   """
 
   @doc """
-  This function is used by `RestAuth.Controller` and loads a user from the database.
+  Used to load user from a data store.
 
-  Must return a `RestAuth.Authority` struct
+  Primary use case is in `RestAuth.Controller.login/2`. Must return a
+  `RestAuth.Authority` struct with all the relevant user information.
 
-  Beware that while `metadata` can be anything it must be serializeable by `Poison` JSON encoder.
-  This can be solved by using the standard types like List, Map etc or by implementing the `Poison` protocol.
+  Beware that while `metadata` can be anything it must be serializeable by
+  `Poison` JSON encoder. This can be solved by using the standard types like List,
+  Map etc or by implementing the `Poison` protocol.
 
-  Do note that all the data returned here will be embedded in the token, so try to keep it as small as possible.
-
+  Do note that all the data returned here will be embedded in the token,
+  so try to keep it as small as possible.
 
   The `:error` reason should be a string explaining why the user was not returned.
   Some examples
-  * "Wrong username and/or password."
-  * "Account is locked"
-  * "Account has not been activated yet".
-  * "Error connecting to database."
 
-  The supplied controller for RestAuth will json respond with either of the two structures:
-
-  ```
-  {
-    "data": {
-              "token": "g3QAAAACZAAEZGF0YW....udlCH1tpI8oPfIE+BsMcrXj2A=",
-              "user_id": 1,
-              "roles": ["user", "admin"],
-              "metadata":  {"name": "John Doe"}
-            }
-  }
-  ```
-
-  ```
-  {
-    "error": <your string here>
-  }
-  ```
+    * "Wrong username and/or password."
+    * "Account is locked"
+    * "Account has not been activated yet".
+    * "Error connecting to database."
   """
-  @callback load_user_data(username::String.t, password::String.t) :: {:ok, RestAuth.Authority.t} | {:error, reason::String.t}
+  @callback load_user_data(username :: String.t, password :: String.t) ::
+            {:ok, RestAuth.Authority.t} | {:error, reason :: String.t}
 
   @doc """
-  Similar to `load_user_data/2` but simply uses the underlaying user from the database to return the Authority.
+  Similar to `load_user_data/2`, but uses an already loaded user data and is only
+  responsible for converting it into the `RestAuth.Authority` struct.
 
-  This function is often used for convenience if a user changes his username, name or other data that requires 
-  the system to issue a new authority for an already known user.
+  This function is often used for convenience if a user changes his username,
+  name or other data that requires the system to issue a new authority for an
+  already known user. It is also used in `RestAuth.Test.authenticate_conn/2`.
   """
   @callback load_user_data(user::any()) :: {:ok, RestAuth.Authority.t}
 
   @doc """
-  Similar to `load_user_data/1` but should get the user from the token. This function is called on every request
-  and should ideally be backed up by `RestAuth.TokenService` or any other caching strategy. If clientside data
-  is outdated, for example by the handler implementing a version field this function can return the authority in
-  a `{:client_outdated, RestAuth.Authority.t}` tuple. This will make the plug add "x-auth-refresh-token": "true"
-  header to the reply.
-  """
-  @callback load_user_data_from_token(token::String.t) :: {:ok, RestAuth.Authority.t} | {:client_outdated, RestAuth.Authority.t} | {:error, reason::String.t}
+  Similar to `load_user_data/1` but constructs the authority struct from
+  the token.
 
-  
-  @doc """
-  Looks up if a given authority can access an item in the system.
-  Typically does a lookup in the caching layer first then in the database 
-  if it is not found there. 
-  
-  If using the caching layer, remember to write-through
-  to the service after loading from the database to decide if access is granted or not.
+  This function is called on every request and should ideally be backed up by
+  `RestAuth.CacheService` or any other caching strategy.
 
-  Remember to use  `invalidate_user_acl/2` to update the acl cache when granting or denying
-  access to things.
+  If clientside data is outdated, for example by the handler implementing
+  a version field this function can return the authority in a
+  `{:client_outdated, RestAuth.Authority.t}` tuple.
+  This will make the plug add "x-auth-refresh-token": "true" header to the reply.
   """
-  @callback can_access_item?(authority :: RestAuth.Authority.t, category :: String.t, target_id :: any()) :: boolean()
+  @callback load_user_data_from_token(token::String.t) ::
+            {:ok, RestAuth.Authority.t} |
+            {:client_outdated, RestAuth.Authority.t} |
+            {:error, reason::String.t}
 
   @doc """
-  Invalidates all user acl based off the `user_id` in the `RestAuth.Authority` struct. 
-  Typically used to clear the acl for a user after being granted access to something.
-  
+  Verifies the given authority can access an item in the system.
+
+  Typically does a lookup for permissions in the caching layer first,
+  then in the database if it is not found there.
+
+  If using the caching layer, remember to write-through to the service after
+  loading from the database to decide if access is granted or not.
+
+  Remember to use  `invalidate_user_acl/2` to update the acl cache when
+  granting or denying access to things.
+  """
+  @callback can_access_item?(RestAuth.Authority.t, category :: String.t, target_id :: any()) :: boolean()
+
+  @doc """
+  Invalidates all user acl based off the `user_id` in the `RestAuth.Authority`
+  struct.
+
+  Typically used to clear the acl for a user after being granted access to
+  something with intention of refreshing the acl data on subsequent requests.
+
   Can be regarded as a companion function
   """
   @callback invalidate_user_acl(authority :: RestAuth.Authority.t) :: :ok | {:error, reason :: String.t}
@@ -86,14 +82,18 @@ defmodule RestAuth.Handler do
   @doc """
   Invalidates a token.
 
-  Typically this invalidates the token in the cacheservice and deletes it from the database.
+  Typically this invalidates the token in the cacheservice and deletes any
+  associated data from the database.
   """
   @callback invalidate_token(authority :: RestAuth.Authority.t) :: :ok | {:error, reason :: String.t}
 
   @doc """
-  Invalidates a user. This effectively logs out all active sessions across the application
+  Invalidates a user.
 
-  Typically this invalidates all the tokens in the cacheservice and deletes them from the database.
+  This effectively logs out all active sessions across the application
+
+  Typically this invalidates all the tokens in the cacheservice and deletes any
+  associated data from the database.
   """
   @callback invalidate_user(authority :: RestAuth.Authority.t) :: :ok | {:error, reason :: String.t}
 

--- a/lib/rest_auth/handler.ex
+++ b/lib/rest_auth/handler.ex
@@ -77,7 +77,8 @@ defmodule RestAuth.Handler do
 
   Can be regarded as a companion function
   """
-  @callback invalidate_user_acl(authority :: RestAuth.Authority.t) :: :ok | {:error, reason :: String.t}
+  @callback invalidate_user_acl(authority :: RestAuth.Authority.t) ::
+            :ok | {:error, reason :: String.t}
 
   @doc """
   Invalidates a token.
@@ -85,7 +86,8 @@ defmodule RestAuth.Handler do
   Typically this invalidates the token in the cacheservice and deletes any
   associated data from the database.
   """
-  @callback invalidate_token(authority :: RestAuth.Authority.t) :: :ok | {:error, reason :: String.t}
+  @callback invalidate_token(authority :: RestAuth.Authority.t) ::
+            :ok | {:error, reason :: String.t}
 
   @doc """
   Invalidates a user.
@@ -95,7 +97,8 @@ defmodule RestAuth.Handler do
   Typically this invalidates all the tokens in the cacheservice and deletes any
   associated data from the database.
   """
-  @callback invalidate_user(authority :: RestAuth.Authority.t) :: :ok | {:error, reason :: String.t}
+  @callback invalidate_user(authority :: RestAuth.Authority.t) ::
+            :ok | {:error, reason :: String.t}
 
   @doc """
   A configuration callback to determine, if mechanisms of `RestAuth` should

--- a/lib/rest_auth/plug_authenticate.ex
+++ b/lib/rest_auth/plug_authenticate.ex
@@ -1,0 +1,100 @@
+defmodule RestAuth.Authenticate do
+  @moduledoc """
+  `RestAuth.Authenticate` is used to load user information into conn.
+
+  It will use the configured handler, to load the authority struct and
+  store it in the connection. The user data can be later accessed using
+  functions from `RestAuth.Utility` module.
+
+  # Example
+
+    plug RestAuth.Authenticate
+
+  """
+
+  require Logger
+
+  import Plug.Conn
+  import Phoenix.Controller, only: [json: 2]
+
+  def init(opts) do
+    opts
+  end
+
+  def call(conn, _opts) do
+    case conn.private do
+      %{rest_auth_authority: %RestAuth.Authority{} = authority} ->
+        Logger.debug "Skipping authentication since #{inspect authority} was already provided in conn"
+        conn
+      _ ->
+        handler = conn.private.rest_auth_handler
+        consume_token(conn, handler)
+    end
+  end
+
+  defp consume_token(conn, handler) do
+    case get_token(conn) do
+      {conn, token, _from_cookie?} when token in [nil, "deleted"] ->
+        anonymous_roles = anonymous_roles(handler)
+        Logger.debug "Header X-Auth-Token not found or deleted, storing anonymous user with roles #{inspect anonymous_roles}"
+        authority = %RestAuth.Authority{roles: anonymous_roles}
+        put_private(conn, :rest_auth_authority, authority)
+      {conn, token, from_cookie?} ->
+        Logger.debug "Found token #{String.slice(token, 1..8)}...., attempting to load user from cache."
+        case handler.load_user_data_from_token(token) do
+          {:ok, authority} ->
+            Logger.debug "Got authority from token"
+            conn
+            |> put_private(:rest_auth_authority, authority)
+          {:client_outdated, authority} ->
+            Logger.debug "Got authority from outdated token"
+            conn
+            |> put_token_refresh(from_cookie?)
+            |> put_private(:rest_auth_authority, authority)
+          # All error conditions will halt the plug pipeline
+          {:error, reason} ->
+            conn
+            |> clean_cookie(from_cookie?)
+            |> put_status(401)
+            |> json(%{"error" => reason})
+            |> halt
+        end
+    end
+  end
+
+  defp get_token(conn) do
+    case get_req_header(conn, "x-auth-token") do
+      [] ->
+        Logger.debug "Trying to fetch token from cookie"
+        conn = fetch_cookies(conn)
+        {conn, Map.get(conn.cookies, "x-auth-token"), true}
+      [token | _] ->
+        {conn, token, false}
+    end
+  end
+
+  defp put_token_refresh(conn, from_cookie?) do
+    if from_cookie? do
+      put_resp_cookie(conn, "x-auth-refresh-token", "true")
+    else
+      put_resp_header(conn, "x-auth-refresh-token", "true")
+    end
+  end
+
+  # If an invalid token comes from cookie, set it to deleted
+  defp clean_cookie(conn, from_cookie?) do
+    if from_cookie? do
+      put_resp_cookie(conn, "x-auth-token", "deleted")
+    else
+      conn
+    end
+  end
+
+  defp anonymous_roles(handler) do
+    if function_exported?(handler, :anonymous_roles, 0) do
+      handler.anonymous_roles()
+    else
+      []
+    end
+  end
+end

--- a/lib/rest_auth/plug_configure.ex
+++ b/lib/rest_auth/plug_configure.ex
@@ -13,6 +13,13 @@ defmodule RestAuth.Configure do
   end
 
   def call(conn, handler) do
-    Plug.Conn.put_private(conn, :rest_auth_handler, handler)
+    case conn.private do
+      %{rest_auth_handler: ^handler} ->
+        conn
+      %{rest_auth_handler: other} ->
+        raise ArgumentError, "conflicting `:rest_auth_handler` found: #{inspect other} while trying to configure #{inspect handler}"
+      _ ->
+        Plug.Conn.put_private(conn, :rest_auth_handler, handler)
+    end
   end
 end

--- a/lib/rest_auth/plug_configure.ex
+++ b/lib/rest_auth/plug_configure.ex
@@ -1,0 +1,18 @@
+defmodule RestAuth.Configure do
+  @moduledoc """
+  Plug responsible for configuring the RestAuth suite on subsequent actions.
+
+  Most other plug-related functionality like `RestAuth.Controller` functions
+  or `RestAuth.Restrict` plug require the configure plug to be applied earlier.
+  """
+
+  @behaviour Plug
+
+  def init(opts) do
+    Keyword.fetch!(opts, :handler)
+  end
+
+  def call(conn, handler) do
+    Plug.Conn.put_private(conn, :rest_auth_handler, handler)
+  end
+end

--- a/lib/rest_auth/plug_restrict.ex
+++ b/lib/rest_auth/plug_restrict.ex
@@ -1,86 +1,75 @@
 defmodule RestAuth.Restrict do
+  @moduledoc """
+  `RestAuth.Restrict` is used to secure endpoints.
+
+  # Example
+
+      @rest_auth_roles  [
+        {:index, ["user"]},
+        {:create, ["admin"]},
+        {:update, ["admin"]},
+        {:show, ["admin"]},
+        {:delete, ["admin"]},
+        {:ping, :permit_all}
+      ]
+      plug RestAuth.Restrict @rest_auth_roles
+
+  In this sample usage I have simply listed the roles in an attribute for readability.
+  The parameter has to be a keyword list of string lists or atom `:permit_all`.
+
+  """
   require Logger
   import Phoenix.Controller, only: [action_name: 1, json: 2]
   import Plug.Conn
 
-  @default_required_roles Application.get_env(:rest_auth, :default_required_roles, [])
-  @anonymous_roles Application.get_env(:rest_auth, :anonymous_roles, [])
-
-  @moduledoc """
-    `RestAuth.Restrict` is where the magic happens.
-
-    Sample usage:
-    ```
-    @rest_auth_roles  [
-                        {:index, ["user"]},
-                        {:create, ["admin"]},
-                        {:update, ["admin"]},
-                        {:show, ["admin"]},
-                        {:delete, ["admin"]}
-                       ]
-    plug RestAuth.Restrict @rest_auth_roles
-    ```
-
-    In this sample usage I have simply listed the roles in an attribute for readability.
-    The parameter has to be a keyword list of string lists.
-    `{:create, "admin"}` will not work.
-
-
-  """
-
-
   @doc """
   Required initiation method
   """
-  def init(default), do: default
+  def init(roles) do
+    Map.new(roles)
+  end
 
   @doc """
-      Checks given roles against current user.
-    """
+  Checks given roles against current user.
+  """
   def call(conn, roles) do
     action = action_name(conn)
-    case (action in Keyword.keys(roles)) do
-      true ->
-        Logger.debug "Securing action #{action} against #{inspect roles[action]}"
+    handler = conn.private.rest_auth_handler
+    case Map.fetch(roles, action) do
+      {:ok, action_roles} ->
+        Logger.debug "Securing action #{action} against #{inspect action_roles}"
         conn
-        |> consume_token()
-        |> check_roles(roles[action])
-      false ->
-        call(conn)
+        |> consume_token(handler)
+        |> check_roles(action_roles)
+      :error ->
+        Logger.debug "Plug called without roles for #{action}, fetching from handler"
+        conn
+        |> consume_token(handler)
+        |> check_roles(handler.default_required_roles())
     end
   end
 
-
-  @doc """
-    If plug is called without for example `roles: ["user", "admin"]`, default role from config will be used
-  """
-  def call(conn) do
-    Logger.debug "Plug called without roles, fetching from handler."
-    conn
-    |> consume_token()
-    |> check_roles(@default_required_roles)
+  defp consume_token(conn, handler) do
+    case conn.private do
+      %{rest_auth_authority: %RestAuth.Authority{} = authority} ->
+        Logger.debug "Skipping authentication since #{inspect authority} was already provided in conn"
+        conn
+      _ ->
+        do_consume_token(conn, handler)
+    end
   end
 
-
-  #Consumes and stores token, 401's if the token is invalid.
-  #Also stores handler on conn
-   defp consume_token(conn) do
-    {conn, auth_token, from_cookie} = case get_req_header(conn, "x-auth-token") do
-      [] ->
-        Logger.debug "Trying to fetch token from cookie"
-        conn = fetch_cookies(conn)
-        {conn, Map.get(conn.cookies, "x-auth-token", nil), true}
-      [token | _ ] ->
-        {conn, token, false}
-    end
-    case auth_token do
-      token when is_nil(token) or token == "deleted" ->
-        Logger.debug "Header X-Auth-Token not found or deleted, storing anonymous user with roles #{inspect @anonymous_roles}"
-        conn
-        |> put_private(:rest_auth_authority, %RestAuth.Authority{})
-      token ->
+  # Consumes and stores token, 401's if the token is invalid.
+  defp do_consume_token(conn, handler) do
+    case get_token(conn) do
+      {conn, token, _from_cookie?} when token in [nil, "deleted"] ->
+        anonymous_roles = handler.anonymous_roles()
+        Logger.debug "Header X-Auth-Token not found or deleted, storing anonymous user with roles #{inspect anonymous_roles}"
+        authority = %RestAuth.Authority{roles: anonymous_roles}
+        put_private(conn, :rest_auth_authority, authority)
+      {conn, token, from_cookie?} ->
         Logger.debug "Found token #{String.slice(token, 1..8)}...., attempting to load user from cache."
-        case handler().load_user_data_from_token(token) do
+        case handler.load_user_data_from_token(token) do
           {:ok, authority} ->
             Logger.debug "Got authority from token"
             conn
@@ -89,48 +78,56 @@ defmodule RestAuth.Restrict do
             conn
             |> put_resp_header("x-auth-refresh-token", true)
             |> put_private(:rest_auth_authority, authority)
-          #Both error conditions will halt the plug pipeline
-          {:error, reason}->
-            #If an invalid token comes from cookie, set it to deleted
-            conn = if from_cookie, do: put_resp_cookie(conn, "x-auth-token", "deleted"), else: conn
+          # All error conditions will halt the plug pipeline
+          {:error, reason} ->
             conn
+            |> clean_cookie(from_cookie?)
             |> put_status(401)
-            |> json(%{ "error" => reason})
+            |> json(%{"error" => reason})
             |> halt
         end
     end
   end
 
-  #If required roles is :permit_all we allow everything by default
+  # If an invalid token comes from cookie, set it to deleted
+  defp clean_cookie(conn, from_cookie?) do
+    if from_cookie? do
+      put_resp_cookie(conn, "x-auth-token", "deleted")
+    else
+      conn
+    end
+  end
+
+  defp get_token(conn) do
+    case get_req_header(conn, "x-auth-token") do
+      [] ->
+        Logger.debug "Trying to fetch token from cookie"
+        conn = fetch_cookies(conn)
+        {conn, Map.get(conn.cookies, "x-auth-token", nil), true}
+      [token | _] ->
+        {conn, token, false}
+    end
+  end
+
   defp check_roles(conn, :permit_all) do
     Logger.debug ":permit_all endpoint, allowing access"
     conn
   end
 
-
-  #Does the actual role check, utilizing `RestAuth.Utility.if_any_granted/1`
   defp check_roles(conn, required_roles) do
-    case  RestAuth.Utility.is_any_granted?(conn, required_roles) do
-      false ->
-        case RestAuth.Utility.is_anonymous?(conn) do
-          true ->
-            conn
-            |> put_status(401)
-            |> json(%{"error" => "not authenticated"})
-            |> halt()
-          false ->
-            conn
-            |> put_status(403)
-            |> json(%{"error" => "you do not have access to this resource"})
-            |> halt()
-        end
+    cond do
+      RestAuth.Utility.is_any_granted?(conn, required_roles) ->
+        conn
+      RestAuth.Utility.is_anonymous?(conn) ->
+        conn
+        |> put_status(401)
+        |> json(%{"error" => "not authenticated"})
+        |> halt()
       true ->
         conn
+        |> put_status(403)
+        |> json(%{"error" => "you do not have access to this resource"})
+        |> halt()
     end
   end
-
-  defp handler() do
-    Application.get_env(:rest_auth, :handler, RestAuth.DummyHandler)
-  end
-
 end

--- a/lib/rest_auth/plug_restrict.ex
+++ b/lib/rest_auth/plug_restrict.ex
@@ -35,6 +35,7 @@ defmodule RestAuth.Restrict do
   def call(conn, roles) do
     action = action_name(conn)
     handler = conn.private.rest_auth_handler
+    check_authority!(conn)
     case Map.fetch(roles, action) do
       {:ok, action_roles} ->
         Logger.debug "Securing action #{action} against #{inspect action_roles}"
@@ -72,6 +73,12 @@ defmodule RestAuth.Restrict do
       handler.default_required_roles()
     else
       []
+    end
+  end
+
+  defp check_authority!(conn) do
+    unless Map.has_key?(conn.private, :rest_auth_authority) do
+      raise ArgumentError, "use of the RestAuth.Authenticate plug is required before using the RestAuth.Restrict plug"
     end
   end
 end

--- a/lib/rest_auth/supervisor.ex
+++ b/lib/rest_auth/supervisor.ex
@@ -1,7 +1,7 @@
 defmodule RestAuth.Supervisor do
   use Supervisor
   @moduledoc false
-  
+
   def start_link do
     Supervisor.start_link(__MODULE__, [])
   end

--- a/lib/rest_auth/test.ex
+++ b/lib/rest_auth/test.ex
@@ -1,0 +1,34 @@
+defmodule RestAuth.Test do
+  @moduledoc """
+  Utilities for testing endpoints using `RestAuth`.
+  """
+
+  @doc """
+  Authenticates connection to bypass the regular header/cookie workflow
+
+  Useful for tests.
+  """
+  def authenticate_conn(conn, user) do
+    handler = conn.private.rest_auth_handler
+    authority = handler.load_user_data(user)
+    Plug.Conn.put_private(conn, :rest_auth_authority, authority)
+  end
+
+  @doc """
+  Allows configuring the test connection.
+
+  Equivalent to calling the `RestAuth.Configure` plug.
+
+  # Example
+
+      # in conn_case.ex
+
+      setup do
+        conn = Phoenix.ConnTest.build_conn()
+        {:ok, RestAuth.Test.configure(conn, handler: MyApp.Handler)}
+      end
+  """
+  def configure(conn, opts) do
+    RestAuth.Configure.call(conn, RestAuth.Configure.init(opts))
+  end
+end

--- a/lib/rest_auth/test.ex
+++ b/lib/rest_auth/test.ex
@@ -10,7 +10,7 @@ defmodule RestAuth.Test do
   """
   def authenticate_conn(conn, user) do
     handler = conn.private.rest_auth_handler
-    authority = handler.load_user_data(user)
+    {:ok, %RestAuth.Authority{} = authority} = handler.load_user_data(user)
     Plug.Conn.put_private(conn, :rest_auth_authority, authority)
   end
 

--- a/lib/rest_auth/utility.ex
+++ b/lib/rest_auth/utility.ex
@@ -58,7 +58,12 @@ defmodule RestAuth.Utility do
   Gets current authority struct saved on `conn`
   """
   def get_authority(conn) do
-    conn.private.rest_auth_authority
+    case conn.private do
+      %{rest_auth_authority: %RestAuth.Authority{} = authority} ->
+        authority
+      _ ->
+        raise ArgumentError, "authority struct not found in the conn"
+    end
   end
 
   # Helper method that does a Set intersection between supplied roles and user roles.

--- a/lib/rest_auth/utility.ex
+++ b/lib/rest_auth/utility.ex
@@ -1,49 +1,29 @@
 defmodule RestAuth.Utility do
-  require Logger
-
   @moduledoc """
   Module is responsible for taking a set of user roles and checking them against required roles on action.
   """
-
+  require Logger
 
   @doc """
   Returns `true` if one or more of the `required_roles` are in users role, `false` if not
   """
   def is_any_granted?(conn, required_roles) do
-    case role_intersection(conn, required_roles) do
-      :all ->
-        true
-      :some ->
-        true
-      :none ->
-        false
-    end
+    role_intersection(conn, required_roles) in [:all, :some]
   end
 
   @doc """
     Returns `true` if all of the `required_roles` are in users role, `false` if not
   """
   def is_all_granted?(conn, required_roles) do
-    case role_intersection(conn, required_roles) do
-      :all ->
-        true
-      _ ->
-        false
-    end
+    role_intersection(conn, required_roles) == :all
   end
 
   @doc """
   Returns `true` if none of the `required_roles` are in users role, `false` if not
   """
   def is_none_granted?(conn, required_roles) do
-    case role_intersection(conn, required_roles) do
-      :none ->
-        true
-      _ ->
-        false
-    end
+    role_intersection(conn, required_roles) == :none
   end
-
 
   @doc """
   Checks if the current user on `conn` is logged in or not
@@ -74,20 +54,23 @@ defmodule RestAuth.Utility do
     conn.private.rest_auth_authority.metadata
   end
 
+  @doc """
+  Gets current authority struct saved on `conn`
+  """
   def get_authority(conn) do
     conn.private.rest_auth_authority
   end
 
-  #Helper method that does a Set intersection between supplied roles and user roles.
+  # Helper method that does a Set intersection between supplied roles and user roles.
   defp role_intersection(conn, required_roles_list) do
-    user_roles = Enum.into (get_current_user_roles(conn)), MapSet.new
-    required_roles = Enum.into required_roles_list, MapSet.new
+    user_roles = MapSet.new(get_current_user_roles(conn))
+    required_roles = MapSet.new(required_roles_list)
     required_roles_size = Enum.count(required_roles)
-    intersection_count = MapSet.intersection(user_roles, required_roles) |> Enum.count
+    intersection_count = Enum.count(MapSet.intersection(user_roles, required_roles))
 
     Logger.debug "Checked user_roles(#{inspect user_roles}) against required_roles(#{inspect required_roles}), intersection_count is (#{intersection_count})"
     case intersection_count do
-      x when x == required_roles_size ->
+      ^required_roles_size ->
         :all
       x when x > 0 ->
         :some
@@ -95,5 +78,4 @@ defmodule RestAuth.Utility do
         :none
     end
   end
-
 end

--- a/mix.exs
+++ b/mix.exs
@@ -8,6 +8,7 @@ defmodule RestAuth.Mixfile do
       elixir: "~> 1.4",
       build_embedded: Mix.env == :prod,
       start_permanent: Mix.env == :prod,
+      elixirc_paths: elixirc_paths(Mix.env),
       description: description(),
       package: package(),
       deps: deps(),
@@ -47,4 +48,7 @@ defmodule RestAuth.Mixfile do
       links: %{"GitHub" => "https://github.com/omttech/rest_auth"}
     ]
   end
+
+  defp elixirc_paths(:test), do: ["lib", "test/support"]
+  defp elixirc_paths(_), do: ["lib"]
 end

--- a/test/rest_auth/cache_service_test.exs
+++ b/test/rest_auth/cache_service_test.exs
@@ -1,0 +1,55 @@
+defmodule RestAuth.CacheServiceTest do
+  # We are only able to set async, since other tests don't use the cache service.
+  # If that changes, remember to disable async or suffer from random failures.
+  use ExUnit.Case, async: true
+
+  alias RestAuth.CacheService
+
+  setup do
+    {:ok, 1} = CacheService.clear()
+    :ok
+  end
+
+  describe "user" do
+    test "get_user returns :not_found without data" do
+      authority = %RestAuth.Authority{user_id: 1, token: "abc"}
+      assert CacheService.get_user(authority) == :not_found
+    end
+
+    test "reads back the user" do
+      authority = %RestAuth.Authority{user_id: 1, token: "abc"}
+      user = %{authority | metadata: %{"foo" => "bar"}}
+      assert CacheService.put_user(user) == {:ok, 1}
+      assert CacheService.get_user(authority) == {:ok, user}
+    end
+
+    test "invalidate_user clears cache" do
+      authority = %RestAuth.Authority{user_id: 1, token: "abc"}
+      assert CacheService.put_user(authority) == {:ok, 1}
+      assert CacheService.invalidate_user(authority) == {:ok, 1}
+      assert CacheService.get_user(authority) == :not_found
+    end
+  end
+
+  describe "acl" do
+    test "can_user_access? returns :not_found without data" do
+      authority = %RestAuth.Authority{user_id: 1}
+      assert CacheService.can_user_access?(authority, "category", 1) == :not_found
+    end
+
+    test "reads back the access" do
+      authority = %RestAuth.Authority{user_id: 1}
+      assert CacheService.put_user_access(authority, "category", 1, true) == {:ok, 1}
+      assert CacheService.can_user_access?(authority, "category", 1)
+      assert CacheService.put_user_access(authority, "category", 2, false) == {:ok, 1}
+      refute CacheService.can_user_access?(authority, "category", 2)
+    end
+
+    test "invalidate_user_access clears cache" do
+      authority = %RestAuth.Authority{user_id: 1}
+      assert CacheService.put_user_access(authority, "category", 1, true) == {:ok, 1}
+      assert CacheService.invalidate_user_access(authority) == {:ok, 1}
+      assert CacheService.can_user_access?(authority, "category", 1) == :not_found
+    end
+  end
+end

--- a/test/rest_auth/controller_test.exs
+++ b/test/rest_auth/controller_test.exs
@@ -1,0 +1,107 @@
+defmodule RestAuth.ControllerTest do
+  use ExUnit.Case, async: true
+
+  import Phoenix.ConnTest
+
+  alias RestAuth.Controller
+
+  setup do
+    conn = Plug.Test.conn(:get, "/")
+    {:ok, conn: RestAuth.Test.configure(conn, handler: RestAuth.TestHandler)}
+  end
+
+  describe "login" do
+    test "without username issues error", %{conn: conn} do
+      params = %{"password" => "123"}
+      resp = Controller.login(conn, params)
+
+      assert %{"error" => _} = json_response(resp, 403)
+      assert resp.halted
+    end
+
+    test "without password issues error", %{conn: conn} do
+      params = %{"username" => "123"}
+      resp = Controller.login(conn, params)
+
+      assert %{"error" => _} = json_response(resp, 403)
+      assert resp.halted
+    end
+
+    test "loads data using the handler", %{conn: conn} do
+      Process.put(:load_user_data_2, fn "foobar", "barfoo" ->
+        {:ok, %RestAuth.Authority{token: "abc"}}
+      end)
+      params = %{"username" => "foobar", "password" => "barfoo"}
+      resp = Controller.login(conn, params)
+
+      assert %{"data" => %{"token" => "abc"}} = json_response(resp, 200)
+    end
+
+    test "responds with error from the handler", %{conn: conn} do
+      Process.put(:load_user_data_2, fn "foobar", "barfoo" ->
+        {:error, "test error"}
+      end)
+      params = %{"username" => "foobar", "password" => "barfoo"}
+      resp = Controller.login(conn, params)
+
+      assert %{"error" => "test error"} = json_response(resp, 403)
+      assert resp.halted
+    end
+
+    test "writes cookie if handler is configured to do so", %{conn: conn} do
+      Process.put(:write_cookie?, true)
+      Process.put(:load_user_data_2, fn "foobar", "barfoo" ->
+        {:ok, %RestAuth.Authority{token: "abc"}}
+      end)
+      params = %{"username" => "foobar", "password" => "barfoo"}
+      resp = Controller.login(conn, params)
+
+      assert %{value: "abc"} == resp.resp_cookies["x-auth-token"]
+    end
+  end
+
+  describe "logout" do
+    setup %{conn: conn} do
+      Process.put(:load_user_data_1, fn _ ->
+        {:ok, %RestAuth.Authority{token: "abc"}}
+      end)
+      auth_conn = RestAuth.Test.authenticate_conn(conn, nil)
+      {:ok, auth_conn: auth_conn}
+    end
+
+    test "requires conn to be authenticated", %{conn: conn} do
+      assert_raise ArgumentError, fn ->
+        Controller.logout(conn)
+      end
+    end
+
+    test "calls invalidate_token", %{auth_conn: conn} do
+      Process.put(:invalidate_token, fn %RestAuth.Authority{token: "abc"} ->
+        send(self(), :token_invalidated)
+        :ok
+      end)
+
+      Controller.logout(conn)
+
+      assert_received :token_invalidated
+    end
+
+    test "responds with success", %{auth_conn: conn} do
+      Process.put(:invalidate_token, fn _ -> :ok end)
+
+      resp = Controller.logout(conn)
+
+      assert %{"success" => "logged out"} = json_response(resp, 200)
+      assert resp.halted
+    end
+
+    test "writes cookie if handler is configured to do so", %{auth_conn: conn} do
+      Process.put(:invalidate_token, fn _ -> :ok end)
+      Process.put(:write_cookie?, true)
+
+      resp = Controller.logout(conn)
+
+      assert %{value: "deleted"} == resp.resp_cookies["x-auth-token"]
+    end
+  end
+end

--- a/test/rest_auth/plug_authenticate_test.exs
+++ b/test/rest_auth/plug_authenticate_test.exs
@@ -5,9 +5,7 @@ defmodule RestAuth.AuthenticateTest do
   import Phoenix.ConnTest
 
   setup do
-    conn =
-      Plug.Test.conn(:get, "/")
-      |> RestAuth.Test.configure(handler: RestAuth.TestHandler)
+    conn = RestAuth.Test.configure(build_conn(), handler: RestAuth.TestHandler)
     {:ok, conn: conn}
   end
 

--- a/test/rest_auth/plug_authenticate_test.exs
+++ b/test/rest_auth/plug_authenticate_test.exs
@@ -1,0 +1,95 @@
+defmodule RestAuth.AuthenticateTest do
+  use ExUnit.Case, async: true
+
+  import Plug.Conn
+  import Phoenix.ConnTest
+
+  setup do
+    conn =
+      Plug.Test.conn(:get, "/")
+      |> RestAuth.Test.configure(handler: RestAuth.TestHandler)
+    {:ok, conn: conn}
+  end
+
+  test "passes through with authority set in conn", %{conn: conn} do
+    Process.put(:load_user_data_1, fn nil ->
+      {:ok, %RestAuth.Authority{token: "abc"}}
+    end)
+    conn = RestAuth.Test.authenticate_conn(conn, nil)
+
+    assert conn == call(conn)
+  end
+
+  test "consumes token from header and succeeds", %{conn: conn} do
+    unique_id = System.unique_integer()
+    Process.put(:load_user_data_from_token, fn "foobarbaz" ->
+      {:ok, %RestAuth.Authority{user_id: unique_id}}
+    end)
+    conn = put_req_header(conn, "x-auth-token", "foobarbaz")
+
+    conn = call(conn)
+    assert RestAuth.Utility.get_authority(conn).user_id == unique_id
+  end
+
+  test "consumes token from header and succeeds outdated", %{conn: conn} do
+    unique_id = System.unique_integer()
+    Process.put(:load_user_data_from_token, fn "foobarbaz" ->
+      {:client_outdated, %RestAuth.Authority{user_id: unique_id}}
+    end)
+    conn = put_req_header(conn, "x-auth-token", "foobarbaz")
+
+    conn = call(conn)
+    assert RestAuth.Utility.get_authority(conn).user_id == unique_id
+    assert get_resp_header(conn, "x-auth-refresh-token") == ["true"]
+  end
+
+  test "consumes token from header and fails", %{conn: conn} do
+    Process.put(:load_user_data_from_token, fn "foobarbaz" ->
+      {:error, "some error"}
+    end)
+    conn = put_req_header(conn, "x-auth-token", "foobarbaz")
+
+    conn = call(conn)
+    assert conn.halted
+    assert %{"error" => "some error"} = json_response(conn, 401)
+  end
+
+  test "consumes token from cookie and succeeds", %{conn: conn} do
+    unique_id = System.unique_integer()
+    Process.put(:load_user_data_from_token, fn "foobarbaz" ->
+      {:ok, %RestAuth.Authority{user_id: unique_id}}
+    end)
+    conn = put_req_cookie(conn, "x-auth-token", "foobarbaz")
+
+    conn = call(conn)
+    assert RestAuth.Utility.get_authority(conn).user_id == unique_id
+  end
+
+  test "consumes token from cookie and succeeds outdated", %{conn: conn} do
+    unique_id = System.unique_integer()
+    Process.put(:load_user_data_from_token, fn "foobarbaz" ->
+      {:client_outdated, %RestAuth.Authority{user_id: unique_id}}
+    end)
+    conn = put_req_cookie(conn, "x-auth-token", "foobarbaz")
+
+    conn = call(conn)
+    assert RestAuth.Utility.get_authority(conn).user_id == unique_id
+    assert conn.resp_cookies["x-auth-refresh-token"] == %{value: "true"}
+  end
+
+  test "consumes token from cookie and fails", %{conn: conn} do
+    Process.put(:load_user_data_from_token, fn "foobarbaz" ->
+      {:error, "some error"}
+    end)
+    conn = put_req_cookie(conn, "x-auth-token", "foobarbaz")
+
+    conn = call(conn)
+    assert conn.halted
+    assert %{"error" => "some error"} = json_response(conn, 401)
+    assert conn.resp_cookies["x-auth-token"] == %{value: "deleted"}
+  end
+
+  def call(conn, opts \\ []) do
+    RestAuth.Authenticate.call(conn, RestAuth.Authenticate.init(opts))
+  end
+end

--- a/test/rest_auth/plug_configure_test.exs
+++ b/test/rest_auth/plug_configure_test.exs
@@ -1,0 +1,39 @@
+defmodule RestAuth.ConfigureTest do
+  use ExUnit.Case, async: true
+
+  alias RestAuth.Configure
+
+  setup do
+    {:ok, conn: Plug.Test.conn(:get, "/")}
+  end
+
+  test "requires handler option" do
+    assert_raise KeyError, ~r":handler", fn ->
+      Configure.init([])
+    end
+  end
+
+  test "sets handler on the connection", %{conn: conn} do
+    conn = call(conn, handler: :handler)
+    assert conn.private.rest_auth_handler == :handler
+  end
+
+  test "refuses to override handler", %{conn: conn} do
+    conn = call(conn, handler: :handler)
+
+    assert_raise ArgumentError, ~r":other_handler", fn ->
+      call(conn, handler: :other_handler)
+    end
+  end
+
+  test "allows setting the same handler twice", %{conn: conn} do
+    conn = call(conn, handler: :handler)
+    conn = call(conn, handler: :handler)
+
+    assert conn.private.rest_auth_handler == :handler
+  end
+
+  defp call(conn, opts) do
+    Configure.call(conn, Configure.init(opts))
+  end
+end

--- a/test/rest_auth/plug_restrict_test.exs
+++ b/test/rest_auth/plug_restrict_test.exs
@@ -1,0 +1,36 @@
+defmodule RestAuth.RestrictTest do
+  use ExUnit.Case, async: true
+
+  import Phoenix.ConnTest
+  import Plug.Conn
+
+  setup do
+    conn =
+      Plug.Test.conn(:get, "/")
+      |> RestAuth.Test.configure(handler: RestAuth.TestHandler)
+      |> put_action(:action)
+    {:ok, conn: conn}
+  end
+
+  # test "passes through with authority set in conn", %{conn: conn} do
+  #   Process.put(:load_user_data_1, fn nil ->
+  #     {:ok, %RestAuth.Authority{token: "abc"}}
+  #   end)
+  #   conn = RestAuth.Test.authenticate_conn(conn, nil)
+
+  #   assert conn == call(conn, [])
+  # end
+
+  # test ""
+
+  def call(conn, opts) do
+    RestAuth.Restrict.call(conn, RestAuth.Restrict.init(opts))
+  end
+
+  # This is using private implementation of phoenix, which is not good.
+  # Unfortunately there's no easy way to set it without setting up a whole
+  # phoenix controller, which is a bit too much
+  defp put_action(conn, action) do
+    put_private(conn, :phoenix_action, action)
+  end
+end

--- a/test/rest_auth/plug_restrict_test.exs
+++ b/test/rest_auth/plug_restrict_test.exs
@@ -1,27 +1,75 @@
 defmodule RestAuth.RestrictTest do
   use ExUnit.Case, async: true
+  @moduletag report: [:authority]
 
   import Phoenix.ConnTest
   import Plug.Conn
 
-  setup do
+  setup %{authority: authority} do
+    Process.put(:load_user_data_1, fn nil ->
+      {:ok, authority}
+    end)
     conn =
-      Plug.Test.conn(:get, "/")
+      build_conn()
       |> RestAuth.Test.configure(handler: RestAuth.TestHandler)
       |> put_action(:action)
-    {:ok, conn: conn}
+    auth_conn = RestAuth.Test.authenticate_conn(conn, nil)
+    {:ok, conn: conn, auth_conn: auth_conn}
   end
 
-  # test "passes through with authority set in conn", %{conn: conn} do
-  #   Process.put(:load_user_data_1, fn nil ->
-  #     {:ok, %RestAuth.Authority{token: "abc"}}
-  #   end)
-  #   conn = RestAuth.Test.authenticate_conn(conn, nil)
+  @tag authority: %RestAuth.Authority{}
+  test "on unauthenticated conn", %{conn: conn} do
+    assert_raise ArgumentError, fn ->
+      call(conn, [])
+    end
+  end
 
-  #   assert conn == call(conn, [])
-  # end
+  describe "anonymous authority" do
+    @describetag authority: %RestAuth.Authority{anonymous: true, roles: ["anonymous"]}
 
-  # test ""
+    test "authenticated when roles match", %{auth_conn: conn} do
+      assert conn == call(conn, [action: ["anonymous"]])
+    end
+
+    test "unauthenticated when roles don't match", %{auth_conn: conn} do
+      conn = call(conn, [action: ["some role"]])
+
+      assert %{"error" => "not authenticated"} = json_response(conn, 401)
+      assert conn.halted
+    end
+  end
+
+  describe "with explicit roles" do
+    @describetag authority: %RestAuth.Authority{anonymous: false, roles: ["abc"]}
+
+    test "authenticated when roles match", %{auth_conn: conn} do
+      assert conn == call(conn, [action: ["abc", "def"]])
+    end
+
+    test "unauthorized when roles don't match", %{auth_conn: conn} do
+      conn = call(conn, [action: ["def"]])
+
+      assert %{"error" => "you do not have access to this resource"} = json_response(conn, 403)
+      assert conn.halted
+    end
+  end
+
+  describe "with default roles" do
+    @describetag authority: %RestAuth.Authority{anonymous: false, roles: ["abc"]}
+
+    test "authenticated when roles match", %{auth_conn: conn} do
+      Process.put(:default_required_roles, ["abc"])
+      assert conn == call(conn, [])
+    end
+
+    test "unauthorized when roles don't match", %{auth_conn: conn} do
+      Process.put(:default_required_roles, ["def"])
+      conn = call(conn, [])
+
+      assert %{"error" => "you do not have access to this resource"} = json_response(conn, 403)
+      assert conn.halted
+    end
+  end
 
   def call(conn, opts) do
     RestAuth.Restrict.call(conn, RestAuth.Restrict.init(opts))

--- a/test/support/test_handler.ex
+++ b/test/support/test_handler.ex
@@ -9,6 +9,10 @@ defmodule RestAuth.TestHandler do
     Process.get(:load_user_data_1).(user)
   end
 
+  def load_user_data_from_token(token) do
+    Process.get(:load_user_data_from_token).(token)
+  end
+
   def write_cookie?() do
     Process.get(:write_cookie?)
   end

--- a/test/support/test_handler.ex
+++ b/test/support/test_handler.ex
@@ -22,6 +22,10 @@ defmodule RestAuth.TestHandler do
   end
 
   def default_required_roles() do
-    Process.get(:default_required_roles)
+    Process.get(:default_required_roles) || []
+  end
+
+  def anonymous_roles() do
+    Process.get(:anonymous_roles) || []
   end
 end

--- a/test/support/test_handler.ex
+++ b/test/support/test_handler.ex
@@ -1,0 +1,19 @@
+defmodule RestAuth.TestHandler do
+  @behaviour RestAuth.Handler
+
+  def load_user_data(username, password) do
+    Process.get(:load_user_data_2).(username, password)
+  end
+
+  def load_user_data(user) do
+    Process.get(:load_user_data_1).(user)
+  end
+
+  def write_cookie?() do
+    Process.get(:write_cookie?)
+  end
+
+  def invalidate_token(token) do
+    Process.get(:invalidate_token).(token)
+  end
+end

--- a/test/support/test_handler.ex
+++ b/test/support/test_handler.ex
@@ -13,11 +13,15 @@ defmodule RestAuth.TestHandler do
     Process.get(:load_user_data_from_token).(token)
   end
 
+  def invalidate_token(token) do
+    Process.get(:invalidate_token).(token)
+  end
+
   def write_cookie?() do
     Process.get(:write_cookie?)
   end
 
-  def invalidate_token(token) do
-    Process.get(:invalidate_token).(token)
+  def default_required_roles() do
+    Process.get(:default_required_roles)
   end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,0 +1,1 @@
+ExUnit.start()

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,2 @@
+Logger.configure(level: :warn)
 ExUnit.start()


### PR DESCRIPTION
* [x] rename `HandlerBehaviour` -> `Handler`
* [x] move `DummyHandler` to `examples` dir from `lib`
* [x] don't change for handlers when starting up
* [x] add `RestAuth.Configure` plug that stores configuration in conn
* [x] move all auth configuration from app env to handler
* [x] add tests
* [x] figure out what to do with `CacheService`