### PR TITLE
Use ErrorHandler.cannot_authenticate for RestAuth.Controller login errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## v2.0.0 (20.08.2018)
+
+Breaking
+
+  * Update `RestAuth.Controller.login/2` errors return `401` by default instead of `403`
+
+Enhancements
+
+  * Update `RestAuth.Controller` to use the error handler for errors
+
+## v1.1.2 (16.08.2018)
+
+Enhancements
+
+  * Add `RestAuth.ErrorHandler` behaviour to permit customization of `Plug` error responses
+  * Add `RestAuth.ErrorHandler.Default` implementation
+  * Update `RestAuth.Configure` to allow `:rest_auth_error_handler` to be set
+  * Update `RestAuth.Authenticate` and `RestAuth.Restrict` to use the error handler for errors
+
 ## v1.1.0 (29.01.2018)
 
 Enhancements

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The library is available on Hex.
 
 ```elixir
 defp deps do
-  [{:rest_auth, "~> 1.0"}]
+  [{:rest_auth, "~> 2.0"}]
 end
 ```
 
@@ -61,6 +61,10 @@ remain to be done:
   * Generators that make skeleton handler modules
   * Generators for token and user schemas for Ecto
   * Periodic reading from the database to flush the token cache for multi node deploys where the nodes are not connected
+
+## Upgrading from 1.x.x to 2.x.x
+
+The only breaking change between versions 1 and 2 are that `RestAuth.Controller.login/2` errors return `401` by default instead of `403`.
 
 ## License
 

--- a/lib/rest_auth/controller.ex
+++ b/lib/rest_auth/controller.ex
@@ -2,8 +2,10 @@ defmodule RestAuth.Controller do
   @moduledoc """
   Generic controller handling login and logout.
   """
-
   require Logger
+
+  alias RestAuth.ErrorHandler
+
   import Phoenix.Controller, only: [json: 2]
   import Plug.Conn, only: [put_status: 2, halt: 1, put_resp_cookie: 4]
 
@@ -47,18 +49,19 @@ defmodule RestAuth.Controller do
         |> json(%{"data" => authority})
 
       {:error, reason} ->
-        conn
-        |> put_status(403)
-        |> json(%{"error" => reason})
-        |> halt
+        error_handler = ErrorHandler.fetch!(conn)
+
+        error_handler.cannot_authenticate(conn, reason, false)
+        |> halt() # Ensure halted
     end
   end
 
   def login(conn, _params) do
-    conn
-    |> put_status(403)
-    |> json(%{"error" => "Username and/or password missing"})
-    |> halt
+    reason = "Username and/or password missing"
+    error_handler = ErrorHandler.fetch!(conn)
+
+    error_handler.cannot_authenticate(conn, reason, false)
+    |> halt() # Ensure halted
   end
 
   @doc """

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule RestAuth.Mixfile do
   use Mix.Project
 
-  @version "1.1.2"
+  @version "2.0.0"
 
   def project do
     [

--- a/test/rest_auth/controller_test.exs
+++ b/test/rest_auth/controller_test.exs
@@ -15,7 +15,7 @@ defmodule RestAuth.ControllerTest do
       params = %{"password" => "123"}
       resp = Controller.login(conn, params)
 
-      assert %{"error" => _} = json_response(resp, 403)
+      assert %{"error" => _} = json_response(resp, 401)
       assert resp.halted
     end
 
@@ -23,7 +23,7 @@ defmodule RestAuth.ControllerTest do
       params = %{"username" => "123"}
       resp = Controller.login(conn, params)
 
-      assert %{"error" => _} = json_response(resp, 403)
+      assert %{"error" => _} = json_response(resp, 401)
       assert resp.halted
     end
 
@@ -44,7 +44,7 @@ defmodule RestAuth.ControllerTest do
       params = %{"username" => "foobar", "password" => "barfoo"}
       resp = Controller.login(conn, params)
 
-      assert %{"error" => "test error"} = json_response(resp, 403)
+      assert %{"error" => "test error"} = json_response(resp, 401)
       assert resp.halted
     end
 


### PR DESCRIPTION
Currently `RestAuth.Controller` returns `403` errors when problems occur during the login process, but it should return `401` errors.

This is a **breaking** change that uses `ErrorHandler.cannot_authenticate` for those errors instead, meaning the default error returned is `401`.